### PR TITLE
Add first-launch program picker

### DIFF
--- a/RoboNexus/ADCHubAPI.swift
+++ b/RoboNexus/ADCHubAPI.swift
@@ -145,14 +145,14 @@ public class ADCHubAPI {
     // MARK: - Dynamic Program ID Support
     public static func selected_program_id() -> Int {
         // Expecting UserSettings.getSelectedProgram() to return "ADC", "VIQRC", "VURC", or "V5RC"
-        let programStr = UserSettings.getSelectedProgram() ?? "ADC"
+        let programStr = UserSettings.getSelectedProgram() ?? ProgramType.viqrc.rawValue
         let mapping: [String: Int] = [
             "Aerial Drone Competition": 44,
             "VEX IQ Robotics Competition": 41,
             "VEX U Robotics Competition": 4,
             "VEX V5 Robotics Competition": 1
         ]
-        return mapping[programStr] ?? 44
+        return mapping[programStr] ?? 41
     }
     
     public static func robotevents_date(date: String, localize: Bool) -> Date? {
@@ -316,7 +316,7 @@ public class ADCHubAPI {
         let seasonID = self.selected_season_id()
         let dispatchGroup = DispatchGroup()
         
-        let programStr = UserSettings.getSelectedProgram() ?? "Aerial Drone Competition"
+        let programStr = UserSettings.getSelectedProgram() ?? ProgramType.viqrc.rawValue
         switch programStr {
         case "Aerial Drone Competition":
             dispatchGroup.enter()
@@ -375,7 +375,7 @@ public class ADCHubAPI {
     /// Returns the WorldSkills object for a given team by checking the appropriate cache
     /// based on the selected program and the team's grade.
     public func world_skills_for(team: Team) -> WorldSkills? {
-        let prog = UserSettings.getSelectedProgram() ?? "Aerial Drone Competition"
+        let prog = UserSettings.getSelectedProgram() ?? ProgramType.viqrc.rawValue
         var cache: WorldSkillsCache
         if prog == "Aerial Drone Competition" {
             if team.grade == "Middle School" {

--- a/RoboNexus/ProgramSelectionPopup.swift
+++ b/RoboNexus/ProgramSelectionPopup.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct ProgramSelectionPopup: View {
+    @EnvironmentObject var settings: UserSettings
+    @EnvironmentObject var configManager: ConfigManager
+    @EnvironmentObject var eventSearch: EventSearch
+
+    @Binding var isPresented: Bool
+    @State private var selectedProgram: ProgramType = {
+        if let stored = UserSettings.getSelectedProgram(),
+           let prog = ProgramType(rawValue: stored) {
+            if prog == .adc && !UserDefaults.standard.bool(forKey: "DeveloperModeEnabled") {
+                return ProgramType.selectableCases.first ?? .viqrc
+            }
+            return prog
+        }
+        return ProgramType.selectableCases.first ?? .viqrc
+    }()
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                Text("Select Your Program")
+                    .font(.headline)
+                Picker("Program", selection: $selectedProgram) {
+                    ForEach(ProgramType.selectableCases) { program in
+                        Text(program.displayName).tag(program)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.wheel)
+                Button("Continue") {
+                    applyProgram()
+                    isPresented = false
+                }
+                .padding()
+            }
+            .navigationTitle("Program")
+        }
+    }
+
+    private func applyProgram() {
+        settings.selectedProgram = selectedProgram.rawValue
+        settings.updateUserDefaults()
+        configManager.updateProgram(to: selectedProgram)
+
+        DispatchQueue.global(qos: .userInteractive).async {
+            API.generate_season_id_map()
+            API.populate_all_world_skills_caches() {
+                let activeSeason = API.get_current_season_id()
+                DispatchQueue.main.async {
+                    settings.setSelectedSeasonID(id: activeSeason)
+                    API.setSelectedSeasonID(id: activeSeason)
+                    settings.updateUserDefaults(updateTopBarContentColor: false)
+                    eventSearch.fetch_events(season_query: activeSeason)
+                }
+            }
+        }
+
+        if let version = UIApplication.appVersion {
+            UserDefaults.standard.set(version, forKey: "lastProgramPromptVersion")
+        }
+    }
+}

--- a/RoboNexus/Settings.swift
+++ b/RoboNexus/Settings.swift
@@ -69,7 +69,11 @@ struct Settings: View {
     var programBinding: Binding<ProgramType> {
         Binding<ProgramType>(
             get: {
-                return ProgramType(rawValue: settings.selectedProgram) ?? .adc
+                let current = ProgramType(rawValue: settings.selectedProgram) ?? .viqrc
+                if current == .adc && !UserDefaults.standard.bool(forKey: "DeveloperModeEnabled") {
+                    return ProgramType.selectableCases.first ?? .viqrc
+                }
+                return current
             },
             set: { newProgram in
                 // Update the program in UserSettings and persist it.
@@ -104,7 +108,7 @@ struct Settings: View {
                 // MARK: - Program Selection Section
                 Section("Program Selection") {
                     Picker("Program", selection: programBinding) {
-                        ForEach(ProgramType.allCases) { program in
+                        ForEach(ProgramType.selectableCases) { program in
                             Text(program.displayName).tag(program)
                         }
                     }

--- a/RoboNexus/UserSettings.swift
+++ b/RoboNexus/UserSettings.swift
@@ -110,8 +110,12 @@ class UserSettings: ObservableObject {
         self.selected_season_id = defaults.object(forKey: "selected_season_id") as? Int
             ?? API.active_season_id()
         
-        // NEW: Initialize the selected program.
-        self.selectedProgram = defaults.object(forKey: "selectedProgram") as? String ?? "Aerial Drone Competition"
+        // NEW: Initialize the selected program, defaulting to the first
+        // selectable program when none is stored. This keeps ADC hidden
+        // when Developer Mode is disabled.
+        self.selectedProgram = defaults.object(forKey: "selectedProgram") as? String
+            ?? ProgramType.selectableCases.first?.rawValue
+            ?? ProgramType.viqrc.rawValue
         
         // NEW: Read haptics toggle from UserDefaults.
         self.enableHaptics = defaults.bool(forKey: "enableHaptics")
@@ -138,8 +142,11 @@ class UserSettings: ObservableObject {
         self.selected_season_id = defaults.object(forKey: "selected_season_id") as? Int
             ?? API.selected_season_id()
         
-        // NEW: Re-read the selected program.
-        self.selectedProgram = defaults.object(forKey: "selectedProgram") as? String ?? "Aerial Drone Competition"
+        // NEW: Re-read the selected program, defaulting to the first selectable
+        // program so ADC remains hidden when developer mode is off.
+        self.selectedProgram = defaults.object(forKey: "selectedProgram") as? String
+            ?? ProgramType.selectableCases.first?.rawValue
+            ?? ProgramType.viqrc.rawValue
         
         // NEW: Re-read haptics setting.
         self.enableHaptics = defaults.bool(forKey: "enableHaptics")

--- a/RoboNexus/UserSettings.swift
+++ b/RoboNexus/UserSettings.swift
@@ -314,6 +314,13 @@ class UserSettings: ObservableObject {
     
     // NEW: Static getter for selected program.
     static func getSelectedProgram() -> String? {
-        return defaults.object(forKey: "selectedProgram") as? String ?? "Aerial Drone Competition"
+        let devMode = defaults.bool(forKey: "DeveloperModeEnabled")
+        if let stored = defaults.object(forKey: "selectedProgram") as? String {
+            if stored == ProgramType.adc.rawValue && !devMode {
+                return ProgramType.selectableCases.first?.rawValue
+            }
+            return stored
+        }
+        return ProgramType.selectableCases.first?.rawValue
     }
 }


### PR DESCRIPTION
## Summary
- hide `Aerial Drone Competition` unless developer mode is enabled
- persist user's stored program when initializing configuration
- filter ADC from program picker on first launch if not in developer mode
- safeguard Settings picker to respect developer mode

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856302a826c83239d3b920e8c21c10c